### PR TITLE
fix: add missing export for `createCatchphrase`

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+export { createCatchphrase } from "./createCatchphrase";
 export { createTranslation } from "./createTranslation";
 export {
   CreateTranslationReturn,


### PR DESCRIPTION
Closes #66